### PR TITLE
remove direct dependency on Test::MinimumVersion

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -13,7 +13,6 @@ Test::MinimumVersion.max_target_perl = 5.008003
 StaticInstall.mode = on
 
 [Prereqs]
-Test::MinimumVersion = 0
 Dist::Zilla = 4
 
 [MetaResources]


### PR DESCRIPTION
This dist doesn't use Test::MinimumVersion directly, but instead it generates a test that uses it. Listing it as a prerequisite means making a build of a dist using this plugin needs to install the module even though it is never used. The test module is injected as a develop prereq, and those should be installed before trying to run author tests.